### PR TITLE
Added packer template for building GDB AWS AMI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Packer Template Changelog
+
+All notable changes to the Packer template for creating GraphDB AMIs will be documented in this file.
+
+## [1.0.0] - 2023-09-14
+
+- Initial release of the Packer template.
+- Added configuration to create GraphDB AMIs on AWS.
+- Added basic provisioning with installation scripts.
+- Added customizable instance type, region, VPC, and subnet.
+- Added README.md with usage instructions.
+- Added CONTRIBUTING.md
+- Added CHANGELOG.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+# Contributing to GraphDB AWS Terraform Module
+
+Here are a few guidelines to help you get started.
+
+## Getting Started
+
+1. Fork this repository.
+2. Clone your forked repository to your local machine.
+3. Create a new branch for your changes: `git checkout -b feature/my-new-feature`.
+4. Make your changes and test them thoroughly.
+5. Commit your changes: `git commit -m "Add some feature"`.
+6. Push your changes to your fork: `git push origin feature/my-new-feature`.
+7. Create a pull request from your branch to the main repository's `main` branch.
+
+## Code Style
+
+Make sure your code follows our and Terraform coding styles.
+
+## Tests
+
+If applicable, add or update tests to ensure your changes work as intended.
+
+## Documentation
+
+If your changes introduce new features, update the documentation to reflect those changes.
+
+## Commit Message Guidelines
+
+Please use meaningful commit messages. Follow the format:
+
+```
+[Type] Short description
+
+Longer description of the changes, especially whys.
+```
+
+Types: `[Feature]`, `[Fix]`, `[Docs]`, `[Refactor]`, `[Chore]`, `[Style]`
+
+## Pull Request Checklist
+
+- [ ] I have tested these changes thoroughly.
+- [ ] My code follows the project's coding style.
+- [ ] I have added appropriate comments to my code, especially in complex areas.
+- [ ] All new and existing tests passed locally.
+
+## Feedback
+
+Feedback and suggestions are welcome! Feel free to open an issue if you have any questions or ideas.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,72 @@
-# packer-aws-graphdb
-Packer configuration for creating an Amazon Machine Image (AMI) for GraphDB.
+# Packer Configuration for Creating GraphDB AMI
+
+This guide explains how to use Packer to create an Amazon Machine Image (AMI) for GraphDB. 
+The Packer configuration in this repository automates the process of installing and configuring GraphDB on an Ubuntu-based EC2 instance.
+
+## Prerequisites
+
+Before you begin, make sure you have the following prerequisites in place:
+
+1. **Packer**: Ensure that you have Packer installed on your local machine.
+2. You can download it from the official Packer website: [Packer Downloads](https://www.packer.io/downloads).
+
+2. **AWS Account**: You should have an AWS account with necessary permissions to create EC2 instances and AMIs.
+
+## Usage
+
+Follow these steps to build an AMI for GraphDB using Packer:
+
+1. **Clone the Repository**:
+
+   ```bash
+   git clone https://github.com/Ontotext-AD/packer-aws-graphdb.git
+   ```
+
+2. **Set Your AWS Credentials**:
+
+   Ensure that your AWS credentials are correctly configured in the AWS CLI configuration.
+
+3. **Edit Variables (Optional)**:
+
+   The Packer configuration allows you to customize various parameters, such as the GraphDB version, AWS region, 
+   instance type, VPC ID, and subnet ID. To do so, create a variables file `variables.pkrvars.hcl`, example file: 
+
+   ```bash
+   gdb_version  = "10.3.2"
+   build_aws_regions = ["eu-central-1"]
+   build_instance_type = "m5.large"
+   build_vpc_id = "<your-vpc-id>"
+   build_subnet_id = "<your-subnet-id>"
+   ```
+
+4. **Build the AMI**:
+
+   Run Packer to build the AMI:
+
+   ```bash
+   packer build -var-file="variables.pkrvars.hcl" aws-ami.pkr.hcl
+   ```
+
+   This command will initiate the Packer build process. Packer will launch an EC2 instance, install GraphDB, 
+   and create an AMI based on the instance.
+
+## Customization
+
+You can customize the Packer configuration and provisioning scripts to suit your specific requirements. 
+
+The following points can be customized in a packer variables file `variables.pkrvars.hcl`:
+
+- **GraphDB Version**: You can change the GraphDB version by modifying the `gdb_version` variable file.
+
+- **AWS Regions**: Modify the `build_aws_region` variable to specify a different AWS region.
+
+- **Instance Type**: Adjust the `build_instance_type` variable to select a different EC2 instance type.
+
+- **Network Configuration**: Update the `build_vpc_id` and `build_subnet_id` variables to match your VPC and subnet settings.
+
+- **Provisioning Scripts**: You can replace or modify the provisioning scripts located in the `./files/` directory. 
+  These scripts and files are copied and executed during the AMI creation process.
+
+## Support
+
+For questions or issues related to this Packer configuration, please [submit an issue](https://github.com/Ontotext-AD/packer-aws-graphdb/issues).

--- a/aws-ami.pkr.hcl
+++ b/aws-ami.pkr.hcl
@@ -1,0 +1,93 @@
+# Packer configuration for creating an Amazon Machine Image (AMI) for GraphDB.
+packer {
+  # Required Packer plugins and their versions.
+  required_plugins {
+    amazon = {
+      version = ">= 1.2.6"
+      source  = "github.com/hashicorp/amazon"
+    }
+  }
+}
+
+######## Variables ######## 
+
+# Defines variables and default values.
+variable "gdb_version" {
+  type    = string
+  default = "10.3.2" # Default GraphDB version.
+}
+
+variable "build_aws_regions" {
+  type    = list(string)
+  default = ["eu-central-1"] # Default AWS region.
+}
+
+variable "build_instance_type" {
+  type    = string
+  default = "m5.large" # Default EC2 instance type for the build.
+}
+
+variable "build_vpc_id" {
+  type    = string
+  default = "" # Default VPC ID.
+}
+
+variable "build_subnet_id" {
+  type    = string
+  default = "" # Default subnet ID.
+}
+
+# Defines a local variable to generate a timestamp for AMI naming.
+locals {
+  timestamp = regex_replace(timestamp(), "[- TZ:]", "")
+}
+
+# Defines the source configuration for the Amazon EBS builder.
+source "amazon-ebs" "ubuntu" {
+  ami_name      = "ami-ontotext-graphdb-${var.gdb_version}-${local.timestamp}"
+  instance_type = "${var.build_instance_type}"
+  vpc_id        = "${var.build_vpc_id}"
+  subnet_id     = "${var.build_subnet_id}"
+  ami_regions = "${var.build_aws_regions}"
+
+  # Specify the source AMI to use as a base.
+  source_ami_filter {
+    filters = {
+      name                = "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+    }
+    most_recent = true
+    owners      = ["099720109477"] # AWS account ID of the owner.
+  }
+
+  # SSH configuration for connecting to the instance.
+  ssh_username                = "ubuntu"
+  associate_public_ip_address = true
+  ssh_interface               = "public_ip"
+
+}
+
+build {
+  name = "graphdb-ami"
+  # Specify the sources for the build, including the Amazon EBS source defined above.
+  sources = [
+    "source.amazon-ebs.ubuntu"
+  ]
+
+  # Provisioning steps
+  provisioner "file" {
+    sources     = ["./files/graphdb.service", "./files/graphdb-cluster-proxy.service", "./files/graphdb.properties", "./files/install_graphdb.sh"]
+    destination = "/tmp/"
+  }
+
+  provisioner "shell" {
+    # Set an environment variable for GraphDB version.
+    environment_vars = [
+      "GRAPHDB_VERSION=${var.gdb_version}",
+    ]
+    # Execute the GraphDB installation script.
+    inline = ["sudo -E bash /tmp/install_graphdb.sh"]
+  }
+
+}

--- a/files/graphdb-cluster-proxy.service
+++ b/files/graphdb-cluster-proxy.service
@@ -1,0 +1,17 @@
+[Unit]
+Description="GraphDB Cluster Proxy"
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Restart=on-failure
+RestartSec=5s
+User=graphdb
+Group=graphdb
+Environment="GDB_JAVA_OPTS=-Dgraphdb.home.conf=/etc/graphdb-cluster-proxy -Dhttp.socket.keepalive=true"
+ExecStart="/opt/graphdb/bin/cluster-proxy"
+TimeoutSec=120
+SuccessExitStatus=143
+
+[Install]
+WantedBy=multi-user.target

--- a/files/graphdb.properties
+++ b/files/graphdb.properties
@@ -1,0 +1,2 @@
+graphdb.home.data=/var/opt/graphdb/data
+graphdb.home.logs=/var/opt/graphdb/logs

--- a/files/graphdb.service
+++ b/files/graphdb.service
@@ -1,0 +1,17 @@
+[Unit]
+Description="GraphDB Engine"
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Restart=on-failure
+RestartSec=5s
+User=graphdb
+Group=graphdb
+Environment="GDB_JAVA_OPTS=-Dgraphdb.home.conf=/etc/graphdb -Dhttp.socket.keepalive=true"
+ExecStart="/opt/graphdb/bin/graphdb"
+TimeoutSec=120
+SuccessExitStatus=143
+
+[Install]
+WantedBy=multi-user.target

--- a/files/install_graphdb.sh
+++ b/files/install_graphdb.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+until ping -c 1 google.com &> /dev/null; do
+  echo "waiting for outbound connectivity"
+  sleep 5
+done
+
+timedatectl set-timezone UTC
+
+# 1. Install Tools
+#apt-get update -y 
+apt update && apt upgrade -y
+apt-get -o DPkg::Lock::Timeout=300 install -y unzip jq nvme-cli openjdk-11-jdk bash-completion
+
+# Create the GraphDB user
+useradd --comment "GraphDB Service User" --create-home --system --shell /bin/bash --user-group graphdb
+
+# Create GraphDB directories
+mkdir -p /var/opt/graphdb/data /var/opt/graphdb/logs /etc/graphdb /etc/graphdb-cluster-proxy /var/opt/graphdb-cluster-proxy/logs
+
+cd /tmp
+curl -O https://maven.ontotext.com/repository/owlim-releases/com/ontotext/graphdb/graphdb/"${GRAPHDB_VERSION}"/graphdb-"${GRAPHDB_VERSION}"-dist.zip
+
+unzip graphdb-"${GRAPHDB_VERSION}"-dist.zip
+rm graphdb-"${GRAPHDB_VERSION}"-dist.zip
+mv graphdb-"${GRAPHDB_VERSION}" /opt/graphdb-"${GRAPHDB_VERSION}"
+ln -s /opt/graphdb-"${GRAPHDB_VERSION}" /opt/graphdb
+
+chown -R graphdb:graphdb /var/opt/graphdb/data /var/opt/graphdb/logs /etc/graphdb /opt/graphdb /opt/graphdb-${GRAPHDB_VERSION} /etc/graphdb-cluster-proxy /var/opt/graphdb-cluster-proxy/logs
+
+mv /tmp/graphdb.properties /etc/graphdb/graphdb.properties
+mv /tmp/graphdb-cluster-proxy.service /lib/systemd/system/graphdb-cluster-proxy.service
+mv /tmp/graphdb.service /lib/systemd/system/graphdb.service
+
+systemctl daemon-reload
+
+systemctl enable graphdb.service
+systemctl start graphdb.service


### PR DESCRIPTION
- Initial release of the Packer template.
- Added configuration to create GraphDB AMIs on AWS.
- Added basic provisioning with installation scripts.
- Added customizable instance type, region, VPC, and subnet.
- Added README.md with usage instructions.
- Added CONTRIBUTING.md
- Added CHANGELOG.md