### PR TITLE
Use the session manager instead of allowing traffic to port 22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the Packer template for creating GraphDB AMIs will be documented in this file.
 
+## [1.2.0]
+
+- Added new configuration for AMI groups `ami_groups`
+- Changed `ssh_interface` to `session_manager`
+- Added `iam_instance_profile` variable required from the `session_manager` 
+- Added `Build_Timestamp` tag to the AMIs
+
 ## [1.1.0]
 
 - Added parallel building of `arm64` and `amd64` based AMIs

--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ The following points can be customized in a packer variables file `variables.pkr
 - **Instance Type**: Adjust the `build_instance_type_arm64` and `build_instance_type_x86-64` variables to select  
   different EC2 instance types for building the AMI images.
 
+- **AMI Groups**: You can specify the groups the AMIs will be made available to via the `ami_groups` variable.
+  A list of strings is accepted. 
+
+- **iam_instance_profile**: AIM Instance profile required for the session manager access. 
+  See https://developer.hashicorp.com/packer/integrations/hashicorp/amazon/latest/components/builder/ebs#session-manager-connections
+
 - **Network Configuration**: Update the `build_vpc_id` and `build_subnet_id` variables to match your VPC and subnet settings.
 
   - **Source AMI**: Use the `source_ami_name_filter_arm64` and `source_ami_name_filter_x86-64` variables to specify the 

--- a/aws-ami.pkr.hcl
+++ b/aws-ami.pkr.hcl
@@ -55,6 +55,16 @@ variable "source_ami_name_filter_x86-64" {
   default     = "ubuntu/images/hvm-ssd/ubuntu-*-22.04-amd64-server-*"
 }
 
+variable "ami_groups" {
+  description = "Groups the AMI will be made available to"
+  type        = list(string)
+}
+
+variable "iam_instance_profile" {
+  description = "IAM instance profile for the SSM"
+  type        = string
+}
+
 # Local variable to generate a timestamp for unique AMI naming.
 locals {
   timestamp = regex_replace(timestamp(), "[- TZ:]", "")
@@ -66,10 +76,12 @@ source "amazon-ebs" "ubuntu-x86-64" {
   vpc_id        = "${var.build_vpc_id}"
   subnet_id     = "${var.build_subnet_id}"
   ami_regions   = "${var.build_aws_regions}"
+  ami_groups    = "${var.ami_groups}"
 
   tags = {
     GDB_Version      = "${var.gdb_version}"
     CPU_Architecture = "x86-64"
+    Build_Timestamp  = "${local.timestamp}"
   }
 
   source_ami_filter {
@@ -84,7 +96,9 @@ source "amazon-ebs" "ubuntu-x86-64" {
 
   ssh_username                = "ubuntu"
   associate_public_ip_address = true
-  ssh_interface               = "public_ip"
+  ssh_interface               = "session_manager"
+  communicator                = "ssh"
+  iam_instance_profile        = "${var.iam_instance_profile}"
 }
 
 source "amazon-ebs" "ubuntu-arm64" {
@@ -93,10 +107,12 @@ source "amazon-ebs" "ubuntu-arm64" {
   vpc_id        = "${var.build_vpc_id}"
   subnet_id     = "${var.build_subnet_id}"
   ami_regions   = "${var.build_aws_regions}"
+  ami_groups    = "${var.ami_groups}"
 
   tags = {
     GDB_Version      = "${var.gdb_version}"
     CPU_Architecture = "arm64"
+    Build_Timestamp  = "${local.timestamp}"
   }
 
   source_ami_filter {
@@ -111,7 +127,9 @@ source "amazon-ebs" "ubuntu-arm64" {
 
   ssh_username                = "ubuntu"
   associate_public_ip_address = true
-  ssh_interface               = "public_ip"
+  ssh_interface               = "session_manager"
+  communicator                = "ssh"
+  iam_instance_profile        = "${var.iam_instance_profile}"
 }
 
 build {


### PR DESCRIPTION
## Description
Use the session manager instead of allowing traffic to port 22

## Related Issues

TES-272

## Changes
- Added new configuration for AMI groups `ami_groups`
- Changed `ssh_interface` to `session_manager`
- Added `iam_instance_profile` variable required from the `session_manager` 

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have tested these changes thoroughly.
- [x] My code follows the project's coding style.
- [x] I have added appropriate comments to my code, especially in complex areas.

