### PR TITLE
TES-254: Persist GraphDB logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to the Packer template for creating GraphDB AMIs will be doc
 
 - Tuned GraphDB's max RAM percentage to allow bigger heap sizes
 - Limited the cluster proxy to 1GB heap at most
+- Configured GraphDB logs to be within GraphDB's data directory
+- Updated the directory structure under /var/opt/graphdb/
+- Properly configured the home directories of GraphDB and its proxy
+- Removed provisioning of graphdb.properties
 
 ## [1.2.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the Packer template for creating GraphDB AMIs will be documented in this file.
 
+## [1.3.0]
+
+- Tuned GraphDB's max RAM percentage to allow bigger heap sizes
+- Limited the cluster proxy to 1GB heap at most
+
 ## [1.2.0]
 
 - Added new configuration for AMI groups `ami_groups`

--- a/aws-ami.pkr.hcl
+++ b/aws-ami.pkr.hcl
@@ -141,7 +141,6 @@ build {
 
   provisioner "file" {
     sources = [
-      "./files/graphdb.properties",
       "./files/graphdb.service",
       "./files/graphdb-cluster-proxy.service",
       "./files/install_graphdb.sh"

--- a/files/graphdb-cluster-proxy.service
+++ b/files/graphdb-cluster-proxy.service
@@ -8,7 +8,7 @@ Restart=on-failure
 RestartSec=5s
 User=graphdb
 Group=graphdb
-Environment="GDB_JAVA_OPTS=-Dgraphdb.home.conf=/etc/graphdb-cluster-proxy -Dhttp.socket.keepalive=true"
+Environment="GDB_JAVA_OPTS=-Dgraphdb.home.conf=/etc/graphdb-cluster-proxy -Dhttp.socket.keepalive=true -Xmx1g"
 ExecStart="/opt/graphdb/bin/cluster-proxy"
 TimeoutSec=120
 SuccessExitStatus=143

--- a/files/graphdb-cluster-proxy.service
+++ b/files/graphdb-cluster-proxy.service
@@ -8,7 +8,7 @@ Restart=on-failure
 RestartSec=5s
 User=graphdb
 Group=graphdb
-Environment="GDB_JAVA_OPTS=-Dgraphdb.home.conf=/etc/graphdb-cluster-proxy -Dhttp.socket.keepalive=true -Xmx1g"
+Environment="GDB_JAVA_OPTS=-Dgraphdb.home=/var/opt/graphdb/cluster-proxy -Dgraphdb.home.conf=/etc/graphdb-cluster-proxy -Dhttp.socket.keepalive=true -Xmx1g"
 ExecStart="/opt/graphdb/bin/cluster-proxy"
 TimeoutSec=120
 SuccessExitStatus=143

--- a/files/graphdb.properties
+++ b/files/graphdb.properties
@@ -1,2 +1,0 @@
-graphdb.home.data=/var/opt/graphdb/data
-graphdb.home.logs=/var/opt/graphdb/logs

--- a/files/graphdb.service
+++ b/files/graphdb.service
@@ -8,7 +8,7 @@ Restart=on-failure
 RestartSec=5s
 User=graphdb
 Group=graphdb
-Environment="GDB_JAVA_OPTS=-Dgraphdb.home.conf=/etc/graphdb -Dhttp.socket.keepalive=true"
+Environment="GDB_JAVA_OPTS=-Dgraphdb.home.conf=/etc/graphdb -Dhttp.socket.keepalive=true -XX:MaxRAMPercentage=85.0 -XX:-UseCompressedOops"
 ExecStart="/opt/graphdb/bin/graphdb"
 TimeoutSec=120
 SuccessExitStatus=143

--- a/files/graphdb.service
+++ b/files/graphdb.service
@@ -8,7 +8,7 @@ Restart=on-failure
 RestartSec=5s
 User=graphdb
 Group=graphdb
-Environment="GDB_JAVA_OPTS=-Dgraphdb.home.conf=/etc/graphdb -Dhttp.socket.keepalive=true -XX:MaxRAMPercentage=85.0 -XX:-UseCompressedOops"
+Environment="GDB_JAVA_OPTS=-Dgraphdb.home=/var/opt/graphdb/node -Dgraphdb.home.conf=/etc/graphdb -Dhttp.socket.keepalive=true -XX:MaxRAMPercentage=85.0 -XX:-UseCompressedOops"
 ExecStart="/opt/graphdb/bin/graphdb"
 TimeoutSec=120
 SuccessExitStatus=143

--- a/files/install_graphdb.sh
+++ b/files/install_graphdb.sh
@@ -35,9 +35,8 @@ useradd --comment "GraphDB Service User" --create-home --system --shell /bin/bas
 # Create GraphDB directories
 mkdir -p /etc/graphdb \
          /etc/graphdb-cluster-proxy \
-         /var/opt/graphdb/data \
-         /var/opt/graphdb/logs \
-         /var/opt/graphdb-cluster-proxy/logs
+         /var/opt/graphdb/node \
+         /var/opt/graphdb/cluster-proxy
 
 # Download and install GraphDB
 cd /tmp
@@ -52,12 +51,9 @@ chown -R graphdb:graphdb /etc/graphdb \
                          /etc/graphdb-cluster-proxy \
                          /opt/graphdb \
                          /opt/graphdb-${GRAPHDB_VERSION} \
-                         /var/opt/graphdb/data \
-                         /var/opt/graphdb/logs \
-                         /var/opt/graphdb-cluster-proxy/logs
+                         /var/opt/graphdb
 
 # Configure systemd for GraphDB and GraphDB proxy
-mv /tmp/graphdb.properties /etc/graphdb/graphdb.properties
 mv /tmp/graphdb-cluster-proxy.service /lib/systemd/system/graphdb-cluster-proxy.service
 mv /tmp/graphdb.service /lib/systemd/system/graphdb.service
 


### PR DESCRIPTION
TES-254: Persist GraphDB logs

- Configured GraphDB logs to be within GraphDB's data directory
- Updated the directory structure under /var/opt/graphdb/
- Properly configured the home directories of GraphDB and its proxy
- Removed provisioning of graphdb.properties

TES-257: Tuned GraphDB memory

- Tuned GraphDB's max RAM percentage to allow bigger heap sizes
- Limited the cluster proxy to 1GB heap at most