### PR TITLE
TES-284 Added the cloudwatch agent to the GDB AMI

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the Packer template for creating GraphDB AMIs will be doc
 ## [1.4.0]
 
 - Installed cloudwatch agent and its needed configurations to be able to push metrics
+- Added editorconfig to the project
 
 ## [1.3.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
-# Packer Template Changelog
+# Changelog
 
 All notable changes to the Packer template for creating GraphDB AMIs will be documented in this file.
+
+## [1.4.0]
+
+- Installed cloudwatch agent and its needed configurations to be able to push metrics
 
 ## [1.3.0]
 
@@ -10,28 +14,28 @@ All notable changes to the Packer template for creating GraphDB AMIs will be doc
 - Updated the directory structure under /var/opt/graphdb/
 - Properly configured the home directories of GraphDB and its proxy
 - Removed provisioning of graphdb.properties
-- Added `ebs_optimized` to be true 
+- Added `ebs_optimized` to be true
 - Added `encrypt_boot` to be false
-- Added shredding of `/root/.ssh/authorized_keys` and `/home/ubuntu/.ssh/authorized_keys` 
+- Added shredding of `/root/.ssh/authorized_keys` and `/home/ubuntu/.ssh/authorized_keys`
 
 ## [1.2.0]
 
 - Added new configuration for AMI groups `ami_groups`
 - Changed `ssh_interface` to `session_manager`
-- Added `iam_instance_profile` variable required from the `session_manager` 
+- Added `iam_instance_profile` variable required from the `session_manager`
 - Added `Build_Timestamp` tag to the AMIs
 
 ## [1.1.0]
 
 - Added parallel building of `arm64` and `amd64` based AMIs
 - Added AWS cli to be installed based on the architecture
-- Added new variables for `arm64` instance type and source AMI  
+- Added new variables for `arm64` instance type and source AMI
 - Renamed `build_instance_type` and `build_instance_type` variables
 - Added default values for `source_ami_name_filter_arm64` and `source_ami_name_filter_x86-64`
 - Changed default instance type for x86-64 to `t3.small`
 - Added tags to the AMIs
 
-## [1.0.0] 
+## [1.0.0]
 
 - Initial release of the Packer template.
 - Added configuration to create GraphDB AMIs on AWS.

--- a/aws-ami.pkr.hcl
+++ b/aws-ami.pkr.hcl
@@ -147,7 +147,9 @@ build {
     sources = [
       "./files/graphdb.service",
       "./files/graphdb-cluster-proxy.service",
-      "./files/install_graphdb.sh"
+      "./files/install_graphdb.sh",
+      "./files/cloudwatch-agent-config.json",
+      "./files/prometheus.yaml"
     ]
     destination = "/tmp/"
   }

--- a/files/cloudwatch-agent-config.json
+++ b/files/cloudwatch-agent-config.json
@@ -1,0 +1,99 @@
+{
+  "agent": {
+    "debug": false
+  },
+  "logs": {
+    "metrics_collected": {
+      "prometheus": {
+        "log_group_name": "graphdb",
+        "prometheus_config_path": "/etc/prometheus/prometheus.yaml",
+        "emf_processor": {
+          "metric_declaration_dedup": true,
+          "metric_namespace": "GraphDB-Metrics",
+          "metric_unit": {
+            "graphdb_nonheap_used_mem": "Bytes",
+            "graphdb_work_dir_used": "Bytes",
+            "graphdb_threads_count": "Count",
+            "graphdb_logs_dir_free": "Bytes",
+            "graphdb_heap_committed_mem": "Bytes",
+            "graphdb_logs_dir_used": "Bytes",
+            "graphdb_heap_max_mem": "Bytes",
+            "graphdb_heap_init_mem": "Bytes",
+            "graphdb_nonheap_init_mem": "Bytes",
+            "graphdb_class_count": "Count",
+            "graphdb_mem_garbage_collections_count": "Count",
+            "graphdb_data_dir_free": "Bytes",
+            "graphdb_nonheap_max_mem": "Bytes",
+            "graphdb_work_dir_free": "Bytes",
+            "graphdb_cpu_load": "Percent",
+            "graphdb_data_dir_used": "Bytes",
+            "graphdb_nonheap_committed_mem": "Bytes",
+            "graphdb_heap_used_mem": "Bytes",
+            "graphdb_open_file_descriptors": "Count",
+            "graphdb_nodes_in_cluster": "Count",
+            "graphdb_nodes_in_sync": "Count",
+            "graphdb_nodes_out_of_sync": "Count",
+            "graphdb_nodes_disconnected": "Count",
+            "graphdb_nodes_syncing": "Count",
+            "graphdb_leader_elections_count": "Count",
+            "graphdb_failure_recoveries_count": "Count"
+          },
+          "metric_declaration": [
+            {
+              "source_labels": [
+                "job"
+              ],
+              "label_matcher": "graphdb_infrastructure_monitor",
+              "dimensions": [
+                [
+                  "host"
+                ]
+              ],
+              "metric_selectors": [
+                "^graphdb_nonheap_used_mem$",
+                "^graphdb_work_dir_used$",
+                "^graphdb_threads_count$",
+                "^graphdb_logs_dir_free$",
+                "^graphdb_heap_committed_mem$",
+                "^graphdb_logs_dir_used$",
+                "^graphdb_heap_max_mem$",
+                "^graphdb_heap_init_mem$",
+                "^graphdb_nonheap_init_mem$",
+                "^graphdb_class_count$",
+                "^graphdb_mem_garbage_collections_count$",
+                "^graphdb_data_dir_free$",
+                "^graphdb_nonheap_max_mem$",
+                "^graphdb_work_dir_free$",
+                "^graphdb_cpu_load$",
+                "^graphdb_data_dir_used$",
+                "^graphdb_nonheap_committed_mem$",
+                "^graphdb_heap_used_mem$",
+                "^graphdb_open_file_descriptors$"
+              ]
+            },
+            {
+              "source_labels": [
+                "job"
+              ],
+              "label_matcher": "graphdb_cluster_monitor",
+              "dimensions": [
+                [
+                  "host"
+                ]
+              ],
+              "metric_selectors": [
+                "^graphdb_nodes_in_cluster$",
+                "^graphdb_nodes_in_sync$",
+                "^graphdb_nodes_out_of_sync$",
+                "^graphdb_nodes_disconnected$",
+                "^graphdb_nodes_syncing$",
+                "^graphdb_leader_elections_count$",
+                "^graphdb_failure_recoveries_count$"
+              ]
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/files/prometheus.yaml
+++ b/files/prometheus.yaml
@@ -1,0 +1,19 @@
+global:
+  scrape_interval: 1m
+  scrape_timeout: 10s
+scrape_configs:
+  - job_name: graphdb_infrastructure_monitor
+    metrics_path: /rest/monitor/infrastructure
+    scrape_interval: 10s
+    static_configs:
+      - targets: [ 'localhost:7200' ]
+  - job_name: graphdb_structures_monitor
+    metrics_path: /rest/monitor/structures
+    scrape_interval: 10s
+    static_configs:
+      - targets: [ 'localhost:7200' ]
+  - job_name: graphdb_cluster_monitor
+    metrics_path: /rest/monitor/cluster
+    scrape_interval: 10s
+    static_configs:
+      - targets: [ 'localhost:7200' ]


### PR DESCRIPTION
- Download and install the cloudwatch agent depending on AMI architecture
- create the necessary configuration to run the agent
- the agent won't be started by default

## Description

<!-- Please, provide a brief description of the changes you've made in this pull request. -->

## Related Issues

<!-- Links to related issues, fixed issues or partially addressed by this PR. -->

## Changes

<!-- List the main changes or features introduced by this PR -->

## Screenshots (if applicable)

<!-- Add any relevant screenshots or GIFs to showcase the changes visually -->

## Checklist

- [x] I have tested these changes thoroughly.
- [x] My code follows the project's coding style.
- [x] I have added appropriate comments to my code, especially in complex areas.
- [x] All new and existing tests passed locally.
