### PR TITLE
GDB-14550: Terraform Automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 # IDEs
-
 .idea/
 
 # Cache objects
@@ -18,3 +17,7 @@ crash.log
 
 # For built boxes
 *.box
+
+# Build artifacts
+manifest.json
+build.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to the Packer template for creating GraphDB AMIs will be documented in this file.
 
+## 1.8.0
+
+- Updated the GraphDB cluster proxy service to use an env file similar to the main GraphDB service
+- Added manifest post-processor to create a manifest JSON with the AMI IDs
+- Renamed the pkr.hcl files to follow a naming convention closer to Terraform
+- Replaced hardcoded ssh_username values with the corresponding variable
+- Added retry count variable for the build provisioner
+- Added a security hardening script that disables modules susceptible to attacks (copy fail, dirty flag)
+- Separated the shell scripts to be in stages (setup, hardening, graphdb)
+- Restructured the build provisioner
+- Updated the setup script to be more robust during retries
+- Narrowed down the AMI filters to be more specific and to use the correct architecture
+- Moved the AMI filters inside the source blocks to make use of the region awareness
+
 ## 1.7.0
 
 - Updated Ubuntu version to 24.04 LTS

--- a/build.pkr.hcl
+++ b/build.pkr.hcl
@@ -7,12 +7,12 @@ build {
 
   provisioner "file" {
     sources = [
-      "./files/graphdb.service",
-      "./files/graphdb-cluster-proxy.service",
-      "./files/install_graphdb.sh",
       "./files/cloudwatch-agent-config.json",
+      "./files/graphdb.env",
+      "./files/graphdb.service",
+      "./files/graphdb-cluster-proxy.env",
+      "./files/graphdb-cluster-proxy.service",
       "./files/prometheus.yaml",
-      "./files/graphdb.env"
     ]
     destination = "/tmp/"
   }
@@ -21,7 +21,25 @@ build {
     environment_vars = [
       "GRAPHDB_VERSION=${var.graphdb_version}",
     ]
-    inline      = ["sudo -E bash /tmp/install_graphdb.sh"]
-    max_retries = 3
+    execute_command = "{{ .Vars }} sudo -E bash '{{ .Path }}'"
+    scripts = [
+      "./files/1-setup.sh",
+      "./files/2-hardening.sh",
+      "./files/3-install-graphdb.sh",
+    ]
+
+    max_retries = var.build_retries
+  }
+
+  provisioner "breakpoint" {
+    disable = !var.build_breakpoint_enabled
+    note    = "Paused for debugging — SSH in now"
+  }
+
+  post-processor "manifest" {
+    output = var.manifest_path
+    custom_data = {
+      graphdb_version = var.graphdb_version
+    }
   }
 }

--- a/files/1-setup.sh
+++ b/files/1-setup.sh
@@ -1,6 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euxo pipefail
+
+export DEBIAN_FRONTEND=noninteractive
 
 until ping -c 1 google.com &>/dev/null; do
   echo "waiting for outbound connectivity"
@@ -17,6 +19,7 @@ wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | tee /et
 # Install Tools
 apt-get -o DPkg::Lock::Timeout=300 update -y
 apt-get -o DPkg::Lock::Timeout=300 install -y bash-completion jq nvme-cli temurin-21-jdk unzip
+
 snap install yq
 
 # Get the server architecture and corresponding AWS CLI
@@ -33,50 +36,21 @@ else
   exit 1
 fi
 
+rm -rf ./aws
 unzip -q awscliv2.zip
-./aws/install
+./aws/install --update
 rm -rf ./awscliv2.zip ./aws
+
+/usr/local/bin/aws --version
 
 dpkg -i -E ./amazon-cloudwatch-agent.deb
 rm amazon-cloudwatch-agent.deb
 
-# Create the GraphDB user
-useradd --comment "GraphDB Service User" --create-home --system --shell /bin/bash --user-group graphdb
-
-# Create GraphDB directories
-mkdir -p /etc/graphdb \
-         /etc/graphdb-cluster-proxy \
-         /var/opt/graphdb/node \
-         /var/opt/graphdb/cluster-proxy
-
-# Download and install GraphDB
-cd /tmp
-curl -O https://maven.ontotext.com/repository/owlim-releases/com/ontotext/graphdb/graphdb/"${GRAPHDB_VERSION}"/graphdb-"${GRAPHDB_VERSION}"-dist.zip
-
-unzip graphdb-"${GRAPHDB_VERSION}"-dist.zip
-rm graphdb-"${GRAPHDB_VERSION}"-dist.zip
-mv graphdb-"${GRAPHDB_VERSION}" /opt/graphdb-"${GRAPHDB_VERSION}"
-ln -s /opt/graphdb-"${GRAPHDB_VERSION}" /opt/graphdb
-
-mv /tmp/graphdb.env /etc/graphdb/graphdb.env
-
-chown -R graphdb:graphdb /etc/graphdb \
-                         /etc/graphdb-cluster-proxy \
-                         /opt/graphdb \
-                         /opt/graphdb-${GRAPHDB_VERSION} \
-                         /var/opt/graphdb
-
-# Configure systemd for GraphDB and GraphDB proxy
-mv /tmp/graphdb-cluster-proxy.service /lib/systemd/system/graphdb-cluster-proxy.service
-mv /tmp/graphdb.service /lib/systemd/system/graphdb.service
-
 # Move the prometheus and cloudwatch configurations
-mkdir "/etc/prometheus"
+mkdir -p /etc/prometheus || true
 mv /tmp/prometheus.yaml /etc/prometheus/prometheus.yaml
+mkdir -p /etc/graphdb/ || true
 mv /tmp/cloudwatch-agent-config.json /etc/graphdb/cloudwatch-agent-config.json
+
 # Disable the agent by default, should be enabled explicitly in the EC2 if needed.
 amazon-cloudwatch-agent-ctl -a stop
-
-systemctl daemon-reload
-systemctl enable graphdb.service
-systemctl start graphdb.service

--- a/files/2-hardening.sh
+++ b/files/2-hardening.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get -o DPkg::Lock::Timeout=300 -y full-upgrade
+apt-get -o DPkg::Lock::Timeout=300 -y install --only-upgrade kmod linux-image-virtual || true
+apt-get -o DPkg::Lock::Timeout=300 -y autoremove
+apt-get -o DPkg::Lock::Timeout=300 -y clean
+
+cat >/etc/modprobe.d/99-hardening-blocklist.conf <<'EOF'
+# Copy Fail
+install algif_aead /bin/false
+blacklist algif_aead
+
+# Dirty Frag
+install esp4 /bin/false
+blacklist esp4
+install esp6 /bin/false
+blacklist esp6
+install rxrpc /bin/false
+blacklist rxrpc
+EOF
+
+for m in algif_aead esp4 esp6 rxrpc; do
+  rmmod "$m" 2>/dev/null || true
+done
+
+update-initramfs -u -k all

--- a/files/3-install-graphdb.sh
+++ b/files/3-install-graphdb.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+# Create the GraphDB user
+useradd --comment "GraphDB Service User" --create-home --system --shell /bin/bash --user-group graphdb
+
+# Create GraphDB directories
+mkdir -p /etc/graphdb \
+         /etc/graphdb-cluster-proxy \
+         /var/opt/graphdb/node \
+         /var/opt/graphdb/cluster-proxy
+
+# Download and install GraphDB
+cd /tmp
+curl -O https://maven.ontotext.com/repository/owlim-releases/com/ontotext/graphdb/graphdb/"${GRAPHDB_VERSION}"/graphdb-"${GRAPHDB_VERSION}"-dist.zip
+
+unzip -q graphdb-"${GRAPHDB_VERSION}"-dist.zip
+rm graphdb-"${GRAPHDB_VERSION}"-dist.zip
+mv graphdb-"${GRAPHDB_VERSION}" /opt/graphdb-"${GRAPHDB_VERSION}"
+ln -s /opt/graphdb-"${GRAPHDB_VERSION}" /opt/graphdb
+
+mv /tmp/graphdb.env /etc/graphdb/graphdb.env
+mv /tmp/graphdb-cluster-proxy.env /etc/graphdb/graphdb-cluster-proxy.env
+
+chown -R graphdb:graphdb /etc/graphdb \
+                         /etc/graphdb-cluster-proxy \
+                         /opt/graphdb \
+                         /opt/graphdb-${GRAPHDB_VERSION} \
+                         /var/opt/graphdb
+
+# Configure systemd for GraphDB and GraphDB proxy
+mv /tmp/graphdb-cluster-proxy.service /lib/systemd/system/graphdb-cluster-proxy.service
+mv /tmp/graphdb.service /lib/systemd/system/graphdb.service
+
+systemctl daemon-reload
+systemctl enable graphdb.service
+systemctl start graphdb.service

--- a/files/graphdb-cluster-proxy.env
+++ b/files/graphdb-cluster-proxy.env
@@ -1,0 +1,1 @@
+GDB_JAVA_OPTS="-Dgraphdb.home=/var/opt/graphdb/cluster-proxy -Dgraphdb.home.conf=/etc/graphdb-cluster-proxy -Dhttp.socket.keepalive=true -Xmx1g"

--- a/files/graphdb-cluster-proxy.service
+++ b/files/graphdb-cluster-proxy.service
@@ -8,7 +8,7 @@ Restart=on-failure
 RestartSec=5s
 User=graphdb
 Group=graphdb
-Environment="GDB_JAVA_OPTS=-Dgraphdb.home=/var/opt/graphdb/cluster-proxy -Dgraphdb.home.conf=/etc/graphdb-cluster-proxy -Dhttp.socket.keepalive=true -Xmx1g"
+EnvironmentFile=/etc/graphdb/graphdb-cluster-proxy.env
 ExecStart=/opt/graphdb/bin/cluster-proxy
 TimeoutSec=120
 SuccessExitStatus=143

--- a/sources.pkr.hcl
+++ b/sources.pkr.hcl
@@ -3,18 +3,23 @@ locals {
   timestamp = regex_replace(timestamp(), "[- TZ:]", "")
 }
 
-data "amazon-ami" "ubuntu_x86_64" {
-  filters = {
-    name                = var.source_ami_name_filter_x86_64
-    root-device-type    = "ebs"
-    virtualization-type = "hvm"
-  }
-  most_recent = true
-  owners      = var.source_ami_owners_x86_64
-}
-
 source "amazon-ebs" "ubuntu_x86_64" {
   skip_create_ami = var.skip_create_ami
+
+  #
+  # Source AMI discovery
+  #
+  source_ami_filter {
+    filters = {
+      name                = var.source_ami_name_filter_x86_64
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+      architecture        = "x86_64"
+
+    }
+    most_recent = true
+    owners      = var.source_ami_owners_x86_64
+  }
 
   #
   # AMI configurations
@@ -56,7 +61,6 @@ source "amazon-ebs" "ubuntu_x86_64" {
   subnet_id = var.build_subnet_id
 
   instance_type        = var.build_instance_type_x86_64
-  source_ami           = data.amazon-ami.ubuntu_x86_64.id
   iam_instance_profile = var.build_iam_instance_profile
   user_data_file       = var.user_data_file
 
@@ -71,22 +75,26 @@ source "amazon-ebs" "ubuntu_x86_64" {
   #
   communicator              = "ssh"
   ssh_interface             = var.ssh_interface
-  ssh_username              = "ubuntu"
+  ssh_username              = var.ssh_username
   ssh_clear_authorized_keys = true
-}
-
-data "amazon-ami" "ubuntu_arm64" {
-  filters = {
-    name                = var.source_ami_name_filter_arm64
-    root-device-type    = "ebs"
-    virtualization-type = "hvm"
-  }
-  most_recent = true
-  owners      = var.source_ami_owners_arm64
 }
 
 source "amazon-ebs" "ubuntu_arm64" {
   skip_create_ami = var.skip_create_ami
+
+  #
+  # Source AMI discovery
+  #
+  source_ami_filter {
+    filters = {
+      name                = var.source_ami_name_filter_arm64
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+      architecture        = "arm64"
+    }
+    most_recent = true
+    owners      = var.source_ami_owners_arm64
+  }
 
   #
   # AMI configurations
@@ -128,7 +136,6 @@ source "amazon-ebs" "ubuntu_arm64" {
   subnet_id = var.build_subnet_id
 
   instance_type        = var.build_instance_type_arm64
-  source_ami           = data.amazon-ami.ubuntu_arm64.id
   iam_instance_profile = var.build_iam_instance_profile
   user_data_file       = var.user_data_file
 
@@ -143,6 +150,6 @@ source "amazon-ebs" "ubuntu_arm64" {
   #
   communicator              = "ssh"
   ssh_interface             = var.ssh_interface
-  ssh_username              = "ubuntu"
+  ssh_username              = var.ssh_username
   ssh_clear_authorized_keys = true
 }

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -5,7 +5,6 @@
 variable "graphdb_version" {
   description = "GraphDB version to install and package as an AMI"
   type        = string
-  default     = "10.6.3"
 }
 
 ####################
@@ -43,7 +42,7 @@ variable "shared_credentials_file_profile" {
 variable "source_ami_name_filter_x86_64" {
   description = "Name filter for the source x86-64 AMI image"
   type        = string
-  default     = "ubuntu/images/hvm-ssd-gp3/ubuntu-*-24.04-amd64-server-*"
+  default     = "ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*"
 }
 
 variable "source_ami_owners_x86_64" {
@@ -55,7 +54,7 @@ variable "source_ami_owners_x86_64" {
 variable "source_ami_name_filter_arm64" {
   description = "Name filter for the source arm64 AMI image"
   type        = string
-  default     = "ubuntu/images/hvm-ssd-gp3/ubuntu-*-24.04-arm64-server-*"
+  default     = "ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-*"
 }
 
 variable "source_ami_owners_arm64" {
@@ -177,6 +176,18 @@ variable "build_tags" {
   default     = {}
 }
 
+variable "build_retries" {
+  description = "Max retries for the build provisioner"
+  type        = number
+  default     = 3
+}
+
+variable "build_breakpoint_enabled" {
+  description = "Toggles the breakpoint provisioner enabling you to troubleshoot the build"
+  type        = bool
+  default     = false
+}
+
 ##########################
 # Communicator variables #
 ##########################
@@ -191,4 +202,14 @@ variable "ssh_username" {
   description = "The username to use when connecting over SSH"
   type        = string
   default     = "ubuntu"
+}
+
+######################
+# Manifest variables #
+######################
+
+variable "manifest_path" {
+  description = "Path to the manifest post-processor output"
+  type        = string
+  default     = "manifest.json"
 }

--- a/versions.pkr.hcl
+++ b/versions.pkr.hcl
@@ -1,8 +1,8 @@
 packer {
   required_plugins {
     amazon = {
-      version = ">= 1.2.6"
       source  = "github.com/hashicorp/amazon"
+      version = "~> 1"
     }
   }
 }


### PR DESCRIPTION
- Updated the GraphDB cluster proxy service to use an env file similar to the main GraphDB service
- Added manifest post-processor to create a manifest JSON with the AMI IDs
- Renamed the pkr.hcl files to follow a naming convention closer to Terraform
- Replaced hardcoded ssh_username values with the corresponding variable
- Added retry count variable for the build provisioner
- Added a security hardening script that disables modules susceptible to attacks (copy fail, dirty flag)
- Separated the shell scripts to be in stages (setup, hardening, graphdb)
- Restructured the build provisioner
- Updated the setup script to be more robust during retries
- Narrowed down the AMI filters to be more specific and to use the correct architecture
- Moved the AMI filters inside the source blocks to make use of the region awareness

Issues GDB-14550 & GDB-14597
